### PR TITLE
Update common.sh

### DIFF
--- a/ssh/common.sh
+++ b/ssh/common.sh
@@ -20,7 +20,7 @@ init_ca() {
 
     # create ca key / cert if key doesn't exist
     if ! test -e "$CAKEYFILE"; then
-      ssh-keygen -N "" -f "$CAKEYFILE"
+      ssh-keygen -t rsa -b 4096 -N "" -f "$CAKEYFILE"
       ssh-keygen \
           -s "$CAKEYFILE" \
           -t rsa-sha2-256 \
@@ -53,7 +53,7 @@ sign_host_credentials() {
     mkdir -p "$(dirname $keyfile)"
     chmod 700 "credentials"
 
-    ssh-keygen -N "" -f "$keyfile"
+    ssh-keygen -t rsa -b 4096 -N "" -f "$keyfile"
     chmod 600 "$keyfile"
     ssh-keygen \
         -s "$CAKEYFILE" \
@@ -87,7 +87,7 @@ sign_upload_credentials() {
 
     mkdir -p "$(dirname $keyfile)"
 
-    ssh-keygen -N "" -f "$keyfile"
+    ssh-keygen -t rsa -b 4096 -N "" -f "$keyfile"
     chmod 600 "$keyfile"
     ssh-keygen \
         -s "$CAKEYFILE" \


### PR DESCRIPTION
Previous version will return "CA key type ssh-ed25519 doesn't match specified rsa-sha2-256" error. Provide "rsa" as ssh-kengen type.