### PR TITLE
Minor fixes for running on macOS

### DIFF
--- a/ssh/common.sh
+++ b/ssh/common.sh
@@ -3,13 +3,13 @@ set -e
 
 # detect correct base64 flags to use
 if echo | base64 -b 0 &> /dev/null; then
-  B64_FLAG="-b 0"
+  B64_FLAG="-b 0 -i"
 else
   B64_FLAG="-w 0"
 fi
 
 b64() {
-  base64 "${B64_FLAG}" "$@"
+  base64 ${B64_FLAG} "$@"
 }
 
 CAKEYFILE="ca/ca"

--- a/ssh/common.sh
+++ b/ssh/common.sh
@@ -13,6 +13,7 @@ b64() {
 }
 
 CAKEYFILE="ca/ca"
+keytype="rsa-sha2-256"
 
 init_ca() {
     mkdir -p "$(dirname $CAKEYFILE)"
@@ -20,10 +21,10 @@ init_ca() {
 
     # create ca key / cert if key doesn't exist
     if ! test -e "$CAKEYFILE"; then
-      ssh-keygen -N "" -f "$CAKEYFILE"
+      ssh-keygen -t $keytype -N "" -f "$CAKEYFILE"
       ssh-keygen \
           -s "$CAKEYFILE" \
-          -t rsa-sha2-256 \
+          -t $keytype \
           -I "beehive ssh ca" \
           -n "beehive" \
           -V "-5m:+3650d" \
@@ -53,11 +54,11 @@ sign_host_credentials() {
     mkdir -p "$(dirname $keyfile)"
     chmod 700 "credentials"
 
-    ssh-keygen -N "" -f "$keyfile"
+    ssh-keygen -t $keytype -N "" -f "$keyfile"
     chmod 600 "$keyfile"
     ssh-keygen \
         -s "$CAKEYFILE" \
-        -t rsa-sha2-256 \
+        -t $keytype \
         -I "$name ssh host key" \
         -n "$name" \
         -V "-5m:+365d" \
@@ -87,11 +88,11 @@ sign_upload_credentials() {
 
     mkdir -p "$(dirname $keyfile)"
 
-    ssh-keygen -N "" -f "$keyfile"
+    ssh-keygen -t $keytype -N "" -f "$keyfile"
     chmod 600 "$keyfile"
     ssh-keygen \
         -s "$CAKEYFILE" \
-        -t rsa-sha2-256 \
+        -t $keytype \
         -I "$name ssh host key" \
         -n "$name" \
         -V "-5m:+365d" \

--- a/tls/common.sh
+++ b/tls/common.sh
@@ -3,13 +3,13 @@ set -e
 
 # detect correct base64 flags to use
 if echo | base64 -b 0 &> /dev/null; then
-  B64_FLAG="-b 0"
+  B64_FLAG="-b 0 -i"
 else
   B64_FLAG="-w 0"
 fi
 
 b64() {
-  base64 "${B64_FLAG}" "$@"
+  base64 ${B64_FLAG} "$@"
 }
 
 CAKEYFILE="ca/cakey.pem"


### PR DESCRIPTION
1. Support for macOS `base64` cli tool.
2. Fix key incompatibility now that `ssh-keygen` defaults have changed.